### PR TITLE
added watt hour unit

### DIFF
--- a/data/derived_unit.yaml
+++ b/data/derived_unit.yaml
@@ -166,6 +166,17 @@
   :property: energy
   :metric: true
   :special: false
+- :names: Watt Hour
+  :symbol: Wh 
+  :primary_code: Wh
+  :secondary_code: Wh
+  :scale:
+    :value: 3600.0
+    :unit_code: J
+  :classification: si
+  :property: energy
+  :metric: true
+  :special: false
   :arbitrary: false
 - :names: Watt
   :symbol: W


### PR DESCRIPTION
Hi Josh,
I've added a Watt Hour unit in data/derived.yaml.

The underlying reason is that I am building some code to allow rails to convert units according to I18n rules, using the atom.property field as a key for the I18n translation (which then does a convert_to on the Unitwise object). Anyway - more of that in another pull request. It just so happens that Wh is a very useful unit if you are monitoring electicity generation or consumption.

Kind regards

Steve
