### PR TITLE
resolve gem dependency conflicts and drop ruby <= 1.9.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: ruby
 cache: bundler
 bundler_args: --without yard pry
+sudo: false
 rvm:
-  - ree
-  - 1.8.7
-  - 1.9.2
   - 1.9.3
   - 2.0.0
   - 2.1
@@ -13,8 +11,6 @@ rvm:
   - rbx-2
 matrix:
   include:
-    - rvm: jruby-18mode
-      env: JRUBY_OPTS="$JRUBY_OPTS --debug"
     - rvm: jruby-19mode
       env: JRUBY_OPTS="$JRUBY_OPTS --debug"
     - rvm: jruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,10 @@
 source 'https://rubygems.org'
 
-if RUBY_VERSION > '1.8.7'
-  gem 'coveralls',  '~> 0.7'
-  if RUBY_VERSION >= '2.2.0'
-    gem 'bigdecimal', '~> 1.2.6', :platform => :mri
-  else
-    gem 'bigdecimal', '~> 1.2.5', :platform => :mri
-  end
+gem 'coveralls',  '~> 0.7'
+if RUBY_VERSION >= '2.2.0'
+  gem 'bigdecimal', '~> 1.2.6', :platform => :mri
+else
+  gem 'bigdecimal', '~> 1.2.5', :platform => :mri
 end
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -251,8 +251,6 @@ Unitwise(1, "meter") / Unitwise(1, "s") # Also works
 This library aims to support and is tested against the following Ruby
 implementations:
 
-* Ruby 1.8.7
-* Ruby 1.9.2
 * Ruby 1.9.3
 * Ruby 2.0.0
 * Ruby 2.1.0

--- a/unitwise.gemspec
+++ b/unitwise.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency               'liner',           '~> 0.2'
   gem.add_dependency               'signed_multiset', '~> 0.2'
   gem.add_dependency               'memoizable',      '~> 0.4'
-  gem.add_dependency               'parslet',         '~> 1.5.0'
+  gem.add_dependency               'parslet',         '~> 1.5'
 
   gem.add_development_dependency   'nokogiri',        '~> 1.5.10'
   gem.add_development_dependency   'pry',             '~> 0.9'


### PR DESCRIPTION
It looks like `unitwise` used to depend on a newer version of `parslet` which in turn relied on an a wider range of versions of `blankslate`. This is back in `v1.0.0` which produces a bunch of warnings for ruby 2.2+.

The currently required `parslet v1.5.0` can only make use of `blankslate ~> 2.0` while `parslet 1.7.0` looks for `blankslate <= 4.0, >= 2.0`. `stripe-ruby-mock` and a few other gems I use would like a more recent `blankslate (>= 3.1.2)`, and this is the only gem that requires the older one.

I'm submitting this PR with the upgraded version to see what travis complains about. If there are issues using the newer version I'll try to fix them too. I'm also happy to work with any reasoning for keeping it at the older version. 

Thanks for a great gem!