### PR TITLE
Allow custom units via Unitwise#register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Unitwise uses semantic versioning.
 
 ### Added
 
+- `Unitwise.register` is a new method that allows user defined units
 - Support for MRI 2.3 and 2.4
 
 ## 2.0.0 - 2015-09-13

--- a/README.md
+++ b/README.md
@@ -237,6 +237,37 @@ Unitwise(1, "meter/s")      # Does not work, mixed designations (name and primar
 Unitwise(1, "meter") / Unitwise(1, "s") # Also works
 ```
 
+
+### Adding custom units
+
+While UCUM's list of units is rather exhaustive, there may still be occasions
+where you need custom or uncommon measurements. You can add them yourself
+with `Unitwise.register`, which will allow you to convert to or from the new
+unit.
+
+For example, if your app needed to pour "3 fingers" of bourbon, you could
+register an atom for that:
+
+```ruby
+Unitwise.register(
+  names: ["finger", "fingers"],
+  symbol: "🥃",
+  primary_code: "fng",
+  secondary_code: "fng",
+  scale: {
+    value: 1.0,
+    unit_code: '[foz_us]'
+  },
+  property: 'fluid volume'
+)
+
+Unitwise(1, "gallon").to_fingers
+# => #<Unitwise::Measurement value=0.153721590464621430998E3 unit=fingers>
+
+Unitwise(1, "🥃").to_cup
+# => #<Unitwise::Measurement value=0.125 unit=cup>
+```
+
 ## Supported Ruby Versions
 
 This library aims to support and is tested against the following Ruby

--- a/lib/unitwise.rb
+++ b/lib/unitwise.rb
@@ -46,6 +46,8 @@ module Unitwise
 
   # Add additional atoms. Useful for registering uncommon or custom units.
   # @param properties [Hash] Properties of the atom
+  # @return [Unitwise::Atom] The newly created atom
+  # @raise [Unitwise::DefinitionError]
   def self.register(atom_hash)
     atom = Unitwise::Atom.new(atom_hash)
     atom.validate!

--- a/lib/unitwise.rb
+++ b/lib/unitwise.rb
@@ -43,7 +43,14 @@ module Unitwise
       false
     end
   end
-  
+
+  # Add additional atoms. Useful for registering uncommon or custom units.
+  # @param properties [Hash] Properties of the atom
+  def self.register(atom_hash)
+    Unitwise::Atom.register(atom_hash)
+    Unitwise::Expression::Decomposer.send(:reset)
+  end
+
   # The system path for the installed gem
   # @api private
   def self.path

--- a/lib/unitwise.rb
+++ b/lib/unitwise.rb
@@ -47,8 +47,11 @@ module Unitwise
   # Add additional atoms. Useful for registering uncommon or custom units.
   # @param properties [Hash] Properties of the atom
   def self.register(atom_hash)
-    Unitwise::Atom.register(atom_hash)
+    atom = Unitwise::Atom.new(atom_hash)
+    atom.validate!
+    Unitwise::Atom.all.push(atom)
     Unitwise::Expression::Decomposer.send(:reset)
+    atom
   end
 
   # The system path for the installed gem

--- a/lib/unitwise/atom.rb
+++ b/lib/unitwise/atom.rb
@@ -126,9 +126,9 @@ module Unitwise
     # @return [true] returns true if the atom is valid
     # @raise [Unitwise::DefinitionError]
     def validate!
-      missing_properties = %i{primary_code names}.select do |prop|
-        val = send(prop)
-        val.nil? || val.empty?
+      missing_properties = %i{primary_code names scale}.select do |prop|
+        val = liner_get(prop)
+        val.nil? || (val.respond_to?(:empty) && val.empty?)
       end
 
       if !missing_properties.empty?

--- a/lib/unitwise/atom.rb
+++ b/lib/unitwise/atom.rb
@@ -7,13 +7,13 @@ module Unitwise
     include Compatible
 
     class << self
-      # Array of hashes representing atom properties.
+      # Array of hashes representing default atom properties.
       # @api private
       def data
         @data ||= data_files.map { |file| YAML.load(File.open file) }.flatten
       end
 
-      # Data files containing atom data
+      # Data files containing default atom data
       # @api private
       def data_files
         %w(base_unit derived_unit).map { |type| Unitwise.data_file type }

--- a/lib/unitwise/atom.rb
+++ b/lib/unitwise/atom.rb
@@ -123,8 +123,8 @@ module Unitwise
     # and that it's scalar and magnitude can be resolved. Note that this method
     # requires the units it depends on to already exist, so it is not used
     # when loading the initial data from UCUM.
-    # @return true returns true if the atom is valid
-    # @raise Unitwise::DefinitionError otherwise
+    # @return [true] returns true if the atom is valid
+    # @raise [Unitwise::DefinitionError]
     def validate!
       missing_properties = %i{primary_code names}.select do |prop|
         send(prop).blank?

--- a/lib/unitwise/atom.rb
+++ b/lib/unitwise/atom.rb
@@ -117,5 +117,33 @@ module Unitwise
       base? ? [Term.new(:atom_code => primary_code)] : scale.root_terms
     end
     memoize :root_terms
+
+
+    # A basic validator for atoms. It checks for the bare minimum properties
+    # and that it's scalar and magnitude can be resolved. Note that this method
+    # requires the units it depends on to already exist, so it is not used
+    # when loading the initial data from UCUM.
+    # @return true returns true if the atom is valid
+    # @raise Unitwise::DefinitionError otherwise
+    def validate!
+      missing_properties = %i{primary_code names}.select do |prop|
+        send(prop).blank?
+      end
+
+      if !missing_properties.empty?
+        missing_list = missing_properties.join(',')
+        raise Unitwise::DefinitionError,
+          "Atom has missing properties: #{missing_list}."
+      end
+
+      msg = "Atom definition could not be resolved. Ensure that it is a base " \
+            "unit or is defined relative to existing units."
+
+      begin
+        !scalar.nil? && !magnitude.nil? || raise(Unitwise::DefinitionError, msg)
+      rescue Unitwise::ExpressionError
+        raise Unitwise::DefinitionError,  msg
+      end
+    end
   end
 end

--- a/lib/unitwise/atom.rb
+++ b/lib/unitwise/atom.rb
@@ -127,7 +127,8 @@ module Unitwise
     # @raise [Unitwise::DefinitionError]
     def validate!
       missing_properties = %i{primary_code names}.select do |prop|
-        send(prop).blank?
+        val = send(prop)
+        val.nil? || val.empty?
       end
 
       if !missing_properties.empty?

--- a/lib/unitwise/base.rb
+++ b/lib/unitwise/base.rb
@@ -12,13 +12,6 @@ module Unitwise
       @all ||= data.map { |d| new d }
     end
 
-    # Add another instance to the collection.
-    # @param properties [Hash] properties for the new instance
-    # @return [Array] The updated collection
-    def self.register(properties)
-      all.push(new properties)
-    end
-
     # Find a matching instance by a specified attribute.
     # @param string [String] The search term
     # @param method [Symbol] The attribute to search by

--- a/lib/unitwise/base.rb
+++ b/lib/unitwise/base.rb
@@ -12,6 +12,13 @@ module Unitwise
       @all ||= data.map { |d| new d }
     end
 
+    # Add another instance to the collection.
+    # @param properties [Hash] properties for the new instance
+    # @return [Array] The updated collection
+    def self.register(properties)
+      all.push(new properties)
+    end
+
     # Find a matching instance by a specified attribute.
     # @param string [String] The search term
     # @param method [Symbol] The attribute to search by

--- a/lib/unitwise/errors.rb
+++ b/lib/unitwise/errors.rb
@@ -1,7 +1,10 @@
 module Unitwise
-  class ExpressionError < Exception
+  class ExpressionError < StandardError
   end
 
-  class ConversionError < Exception
+  class ConversionError < StandardError
+  end
+
+  class DefinitionError < StandardError
   end
 end

--- a/lib/unitwise/expression/decomposer.rb
+++ b/lib/unitwise/expression/decomposer.rb
@@ -7,10 +7,6 @@ module Unitwise
 
       MODES = [:primary_code, :secondary_code, :names, :slugs, :symbol]
 
-      PARSERS = MODES.reduce({}) do |hash, mode|
-        hash[mode] = Parser.new(mode); hash
-      end
-
       TRANSFORMER = Transformer.new
 
       class << self
@@ -25,12 +21,30 @@ module Unitwise
           end
         end
 
+        def parsers
+          @parsers ||= MODES.reduce({}) do |hash, mode|
+            hash[mode] = Parser.new(mode); hash
+          end
+        end
+
+        def transformer
+          @transformer = Transformer.new
+        end
+
         private
 
         # A simple cache to prevent re-decomposing the same units
         # api private
         def cache
           @cache ||= {}
+        end
+
+        # Reset memoized data. Allows rebuilding of parsers, transformers, and
+        # the cache after list of atoms has been modified.
+        def reset
+          @parsers = nil
+          @transformer = nil
+          @cache = nil
         end
       end
 
@@ -44,7 +58,7 @@ module Unitwise
       end
 
       def parse
-        PARSERS.reduce(nil) do |_, (mode, parser)|
+        self.class.parsers.reduce(nil) do |_, (mode, parser)|
           parsed = parser.parse(expression) rescue next
           @mode = mode
           break parsed
@@ -52,7 +66,7 @@ module Unitwise
       end
 
       def transform
-        @transform ||= TRANSFORMER.apply(parse, :mode => mode)
+        @transform ||= self.class.transformer.apply(parse, :mode => mode)
       end
 
       def terms

--- a/lib/unitwise/expression/decomposer.rb
+++ b/lib/unitwise/expression/decomposer.rb
@@ -5,9 +5,7 @@ module Unitwise
     # of a string, as well as caching the results.
     class Decomposer
 
-      MODES = [:primary_code, :secondary_code, :names, :slugs, :symbol]
-
-      TRANSFORMER = Transformer.new
+      MODES = [:primary_code, :secondary_code, :names, :slugs, :symbol].freeze
 
       class << self
 

--- a/lib/unitwise/expression/matcher.rb
+++ b/lib/unitwise/expression/matcher.rb
@@ -5,19 +5,15 @@ module Unitwise
     class Matcher
       class << self
         def atom(mode)
-          @atom ||= {}
-          @atom[mode] ||= new(Atom.all, mode).alternative
+          new(Atom.all, mode).alternative
         end
 
         def metric_atom(mode)
-          @metric_atom ||= {}
-          @metric_atom[mode] ||=
-            new(Atom.all.select(&:metric?), mode).alternative
+          new(Atom.all.select(&:metric?), mode).alternative
         end
 
         def prefix(mode)
-          @prefix ||= {}
-          @prefix[mode] ||= new(Prefix.all, mode).alternative
+          new(Prefix.all, mode).alternative
         end
       end
 
@@ -41,7 +37,6 @@ module Unitwise
       def alternative
         Parslet::Atoms::Alternative.new(*matchers)
       end
-
     end
   end
 end

--- a/lib/unitwise/expression/parser.rb
+++ b/lib/unitwise/expression/parser.rb
@@ -5,14 +5,21 @@ module Unitwise
     class Parser < Parslet::Parser
       attr_reader :key
       def initialize(key = :primary_code)
-        @key = key
+        @key                 = key
+        @atom_matcher        = Matcher.atom(key)
+        @metric_atom_matcher = Matcher.metric_atom(key)
+        @prefix_matcher      = Matcher.prefix(key)
       end
+
+      private
+
+      attr_reader :atom_matcher, :metric_atom_matcher, :prefix_matcher
 
       root :expression
 
-      rule (:atom) { Matcher.atom(key).as(:atom_code) }
-      rule (:metric_atom) { Matcher.metric_atom(key).as(:atom_code) }
-      rule (:prefix) { Matcher.prefix(key).as(:prefix_code) }
+      rule (:atom) { atom_matcher.as(:atom_code) }
+      rule (:metric_atom) { metric_atom_matcher.as(:atom_code) }
+      rule (:prefix) { prefix_matcher.as(:prefix_code) }
 
       rule (:simpleton) do
         (prefix.as(:prefix) >> metric_atom.as(:atom) | atom.as(:atom))

--- a/test/unitwise/atom_test.rb
+++ b/test/unitwise/atom_test.rb
@@ -126,4 +126,41 @@ describe Unitwise::Atom do
       second.frozen?.must_equal true
     end
   end
+
+  describe "validate!" do
+    it "returns true for a valid atom" do
+      atom = Unitwise::Atom.new(
+        primary_code: "warp",
+        secondary_code: "[warp]",
+        names: ["Warp", "Warp Factor"],
+        scale: {
+          value: 1,
+          unit_code: "[c]"
+        }
+      )
+
+      atom.validate!.must_equal true
+    end
+
+    it "returns an error for an atom with missing properties" do
+      atom = Unitwise::Atom.new(names: "hot dog")
+
+      assert_raises { atom.validate! }
+    end
+
+    it "returns an error for an atom that doesn't resolve" do
+      atom = Unitwise::Atom.new(
+        primary_code: "feels",
+        secondary_code: "FEELS",
+        names: ["feels"],
+        scale: {
+          value: 1,
+          unit_code: "hearts"
+        }
+      )
+
+      atom.validate!
+      assert_raises { atom.validate! }
+    end
+  end
 end

--- a/test/unitwise/atom_test.rb
+++ b/test/unitwise/atom_test.rb
@@ -31,7 +31,7 @@ describe Unitwise::Atom do
   let(:joule)   { Unitwise::Atom.find("J")}
   describe "#scale" do
     it "must be nil for base atoms" do
-      second.scale.must_equal nil
+      second.scale.must_be_nil
     end
     it "sould be a Scale object for derived atoms" do
       yard.scale.must_be_instance_of Unitwise::Scale

--- a/test/unitwise/atom_test.rb
+++ b/test/unitwise/atom_test.rb
@@ -159,7 +159,6 @@ describe Unitwise::Atom do
         }
       )
 
-      atom.validate!
       assert_raises { atom.validate! }
     end
   end

--- a/test/unitwise_test.rb
+++ b/test/unitwise_test.rb
@@ -28,8 +28,28 @@ describe Unitwise do
     end
   end
 
+  describe 'register' do
+    it 'should allow custom units to be registered' do
+      josh = {
+        names: ["Josh W Lewis", "joshwlewis"],
+        symbol: "JWL",
+        primary_code: "jwl",
+        secondary_code: "jwl",
+        scale: {
+          value: 71.875,
+          unit_code: "[in_i]"
+        }
+      }
+
+      Unitwise.register(josh)
+
+      joshes = Unitwise(1, 'mile').to_jwl
+
+      joshes.to_i.must_equal(881)
+    end
+  end
+
   it "should have a path" do
     Unitwise.path.must_match(/unitwise$/)
   end
-
 end


### PR DESCRIPTION
There have been numerous requests for adding one-off, custom, or unsual units to Unitwise. I've not supported these requests in the past because:

1) This gem is an implementation of [UCUM](http://unitsofmeasure.org), which curates a canonical source of units, and any units added to this gem are likely to conflict (or may in the future).
2) I don't want to maintain a list of units and their conversion values. This is exactly what [UCUM](http://unitsofmeasure.org) exists to do.

However, there is value in supporting user-defined units. Some domains have legitimate units that don't make sense in UCUM.

This PR supports user-defined units via `Unitwise.register()`. It takes a hash of atom properties. For example, if your app had to measure bourbon in fingers ("three fingers of whiskey, please"):

```ruby
Unitwise.register(
  names: ["finger", "fingers"],
  symbol: "🥃",
  primary_code: "fng",
  secondary_code: "fng",
  scale: {
    value: 1.0,
    unit_code: '[foz_us]'
  }
  property: 'fluid volume'
)
```

And now you can convert to and from it:

```
Unitwise(1, "gallon").to_fingers
```
   
  