### PR TITLE
Update bigdecimal dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,9 @@ source 'https://rubygems.org'
 
 gem 'coveralls',  '~> 0.7'
 if RUBY_VERSION >= '2.2.0'
-  gem 'bigdecimal', '~> 1.2.6', :platform => :mri
+  gem 'bigdecimal', '>= 1.2.6', :platform => :mri
 else
-  gem 'bigdecimal', '~> 1.2.5', :platform => :mri
+  gem 'bigdecimal', '<= 1.2.5', :platform => :mri
 end
 
 gemspec


### PR DESCRIPTION
This gem was outdated. Note that newer versions of bigdecimal are still not compatible with older rubies.