### PR TITLE
Fix [35] floating point inaccuracy

### DIFF
--- a/lib/unitwise/term.rb
+++ b/lib/unitwise/term.rb
@@ -126,7 +126,7 @@ module Unitwise
 
     # @api private
     def calculate(value)
-      (factor * (prefix ? prefix.scalar : 1) * value) ** exponent
+      (factor * (prefix ? prefix.scalar : 1) * value.to_s.to_r) ** exponent
     end
 
     # Multiply or divide a term

--- a/test/unitwise/scale_test.rb
+++ b/test/unitwise/scale_test.rb
@@ -4,4 +4,16 @@ require 'support/scale_tests'
 describe Unitwise::Scale do
   let(:described_class) { Unitwise::Scale }
   include ScaleTests
+
+  # Regression tests for issue [35]
+  it "must convert to feet and back to meter without loss of precision" do
+    m = Unitwise(10, 'm')
+    feet = m.to_foot
+    feet.to_meter.to_f.must_equal(10)
+  end
+
+  it "must convert circle to degree without loss of precision" do
+    circle = Unitwise(1, 'circle')
+    circle.convert_to('degree').to_f.must_equal(360)
+  end
 end


### PR DESCRIPTION
A floating point inaccuracy has been reported in issue joshwlewis/unitwise#35.
I should have fixed it, and added two regression tests simulating the behaviour
reported in the issue.