### PR TITLE
update: prioritise atomic units to prefixed units

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,12 @@
+AllCops:
+  Include:
+    - Rakefile
+    - config.ru
+  Exclude:
+    - Gemfile
+    - unitwise.gemspec
+  TargetRubyVersion: 2.4
+Documentation:
+  Enabled: true
+Metrics/LineLength:
+  Max: 80

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,6 @@ source 'https://rubygems.org'
 
 gem 'coveralls',  '~> 0.7'
 gem 'bigdecimal', '>= 1.2.6', :platform => :mri
+gem 'rubocop', '~> 0.51.0', require: false
 
 gemspec

--- a/lib/unitwise/expression.rb
+++ b/lib/unitwise/expression.rb
@@ -1,8 +1,11 @@
+# frozen_string_literal: true
+
+require 'unitwise/expression/atomic_parser'
+require 'unitwise/expression/composer'
+require 'unitwise/expression/decomposer'
 require 'unitwise/expression/matcher'
 require 'unitwise/expression/parser'
 require 'unitwise/expression/transformer'
-require 'unitwise/expression/composer'
-require 'unitwise/expression/decomposer'
 
 module Unitwise
   # The Expression module encompases all functions around encoding and decoding

--- a/lib/unitwise/expression/atomic_parser.rb
+++ b/lib/unitwise/expression/atomic_parser.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module Unitwise
+  module Expression
+    # Special parser to prioritise parsing of expressions without prefixes.
+    #
+    # This is added as prefixed matches can take precedence over non-prefixed
+    # :symbol matches. An example of this would be the expression "ft".
+    #
+    #   # Unitwise::Expression::Parser.new.parse("ft")
+    #   # => {
+    #   #      :left => {
+    #   #        :term => {
+    #   #          :prefix => {
+    #   #            :prefix_code => "f"@0
+    #   #          },
+    #   #          :atom => {
+    #   #            :atom_code => "t"@1
+    #   #          }
+    #   #        }
+    #   #      }
+    #   #    }
+    #
+    # Where in most common use cases, it is probably more intuitive to have "ft"
+    # be matched to the atom "foot":
+    #
+    #   # Unitwise::Expression::AtomicParser.new(:symbol).parse("ft")
+    #   # => {
+    #   #      :left => {
+    #   #        :term => {
+    #   #          :atom => {
+    #   #            :atom_code => "ft"@0
+    #   #          }
+    #   #        }
+    #   #      }
+    #   #    }
+    #
+    # AtomicParser should only be needed for :primary_code, :secondary_code and
+    # :symbol type matches
+    #
+    class AtomicParser < Parslet::Parser
+      attr_reader :key
+
+      def initialize(key = :primary_code)
+        @key                 = key
+        @atom_matcher        = Matcher.atom(key)
+        @metric_atom_matcher = Matcher.metric_atom(key)
+      end
+
+      private
+
+      attr_reader :atom_matcher, :metric_atom_matcher
+
+      root :expression
+
+      rule(:atom) { atom_matcher.as(:atom_code) }
+      rule(:metric_atom) { metric_atom_matcher.as(:atom_code) }
+
+      rule(:simpleton) do
+        metric_atom.as(:atom) | atom.as(:atom)
+      end
+
+      rule(:annotation) do
+        str('{') >> match['^}'].repeat.as(:annotation) >> str('}')
+      end
+
+      rule(:digits) { match['0-9'].repeat(1) }
+
+      rule(:integer) { (str('-').maybe >> digits).as(:integer) }
+
+      rule(:fixnum) do
+        (str('-').maybe >> digits >> str('.') >> digits).as(:fixnum)
+      end
+
+      rule(:number) { fixnum | integer }
+
+      rule(:exponent) { integer.as(:exponent) }
+
+      rule(:factor) { number.as(:factor) }
+
+      rule(:operator) { (str('.') | str('/')).as(:operator) }
+
+      rule(:term) do
+        (
+          ((factor >> simpleton) | simpleton | factor) >>
+            exponent.maybe >>
+            annotation.maybe
+        ).as(:term)
+      end
+
+      rule(:group) do
+        (factor.maybe >> str('(') >> expression.as(:nested) >> str(')') >>
+          exponent.maybe).as(:group)
+      end
+
+      rule(:expression) do
+        (group | term).as(:left).maybe >>
+          (operator >> expression.as(:right)).maybe
+      end
+    end
+  end
+end

--- a/lib/unitwise/expression/parser.rb
+++ b/lib/unitwise/expression/parser.rb
@@ -1,9 +1,12 @@
+# frozen_string_literal: true
+
 module Unitwise
   module Expression
     # Parses a string expression into a hash tree representing the
     # expression's terms, prefixes, and atoms.
     class Parser < Parslet::Parser
       attr_reader :key
+      
       def initialize(key = :primary_code)
         @key                 = key
         @atom_matcher        = Matcher.atom(key)
@@ -17,49 +20,48 @@ module Unitwise
 
       root :expression
 
-      rule (:atom) { atom_matcher.as(:atom_code) }
-      rule (:metric_atom) { metric_atom_matcher.as(:atom_code) }
-      rule (:prefix) { prefix_matcher.as(:prefix_code) }
+      rule(:atom) { atom_matcher.as(:atom_code) }
+      rule(:metric_atom) { metric_atom_matcher.as(:atom_code) }
+      rule(:prefix) { prefix_matcher.as(:prefix_code) }
 
-      rule (:simpleton) do
-        (prefix.as(:prefix) >> metric_atom.as(:atom) | atom.as(:atom))
+      rule(:simpleton) do
+        prefix.as(:prefix) >> metric_atom.as(:atom) | atom.as(:atom)
       end
 
-      rule (:annotation) do
-        str('{') >> match['^}'].repeat.as(:annotation) >> str('}')
+      rule(:annotation) do
+        str("{") >> match["^}"].repeat.as(:annotation) >> str("}")
       end
 
-      rule (:digits) { match['0-9'].repeat(1) }
+      rule(:digits) { match["0-9"].repeat(1) }
 
-      rule (:integer) { (str('-').maybe >> digits).as(:integer) }
+      rule(:integer) { (str("-").maybe >> digits).as(:integer) }
 
-      rule (:fixnum) do
-        (str('-').maybe >> digits >> str('.') >> digits).as(:fixnum)
+      rule(:fixnum) do
+        (str("-").maybe >> digits >> str(".") >> digits).as(:fixnum)
       end
 
-      rule (:number) { fixnum | integer }
+      rule(:number) { fixnum | integer }
 
-      rule (:exponent) { integer.as(:exponent) }
+      rule(:exponent) { integer.as(:exponent) }
 
-      rule (:factor) { number.as(:factor) }
+      rule(:factor) { number.as(:factor) }
 
-      rule (:operator) { (str('.') | str('/')).as(:operator) }
+      rule(:operator) { (str(".") | str("/")).as(:operator) }
 
-      rule (:term) do
+      rule(:term) do
         ((factor >> simpleton | simpleton | factor) >>
           exponent.maybe >> annotation.maybe).as(:term)
       end
 
-      rule (:group) do
-        (factor.maybe >> str('(') >> expression.as(:nested) >> str(')') >>
+      rule(:group) do
+        (factor.maybe >> str("(") >> expression.as(:nested) >> str(")") >>
           exponent.maybe).as(:group)
       end
 
-      rule (:expression) do
-        ((group | term).as(:left)).maybe >>
+      rule(:expression) do
+        (group | term).as(:left).maybe >>
           (operator >> expression.as(:right)).maybe
       end
-
     end
   end
 end

--- a/lib/unitwise/unit.rb
+++ b/lib/unitwise/unit.rb
@@ -25,14 +25,14 @@ module Unitwise
     # @return [Array]
     # @api public
     def terms
-      unless frozen?
-        unless @terms
-          decomposer = Expression.decompose(@expression)
-          @mode  = decomposer.mode
-          @terms = decomposer.terms
-        end
-        freeze
-      end
+      return @terms if frozen?
+      return @terms if !@terms.nil? && @terms.any?
+
+      decomposer = Expression.decompose(@expression)
+      @mode  = decomposer.mode
+      @terms = decomposer.terms
+      freeze
+
       @terms
     end
 

--- a/test/unitwise/expression/atomic_parser_test.rb
+++ b/test/unitwise/expression/atomic_parser_test.rb
@@ -1,0 +1,191 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+describe Unitwise::Expression::AtomicParser do
+  describe 'when parser is initialized with :primary_code as key' do
+    subject { Unitwise::Expression::AtomicParser.new }
+
+    describe '#metric_atom' do
+      it "must match 'N'" do
+        subject.metric_atom.parse('N')[:atom_code].must_equal('N')
+      end
+
+      it "must match 't'" do
+        subject.atom.parse('t')[:atom_code].must_equal('t')
+      end
+    end
+
+    describe '#atom' do
+      it "must match '[in_i]'" do
+        subject.atom.parse('[in_i]')[:atom_code].must_equal('[in_i]')
+      end
+
+      it "must match '[ft_i]'" do
+        subject.atom.parse('[ft_i]')[:atom_code].must_equal('[ft_i]')
+      end
+    end
+
+    describe '#annotation' do
+      it "must match '{foobar}'" do
+        subject.annotation.parse('{foobar}')[:annotation].must_equal('foobar')
+      end
+    end
+
+    describe '#factor' do
+      it 'must match positives and fixnums' do
+        subject.factor.parse('3.2')[:factor].must_equal(fixnum: '3.2')
+      end
+
+      it 'must match negatives and integers' do
+        subject.factor.parse('-5')[:factor].must_equal(integer: '-5')
+      end
+    end
+
+    describe '#exponent' do
+      it 'must match positives integers' do
+        subject.exponent.parse('4')[:exponent].must_equal(integer: '4')
+      end
+
+      it 'must match negative integers' do
+        subject.exponent.parse('-5')[:exponent].must_equal(integer: '-5')
+      end
+    end
+
+    describe 'term' do
+      it 'must match basic atoms' do
+        subject.term.parse('[in_i]')[:term][:atom][:atom_code]
+               .must_equal('[in_i]')
+      end
+
+      it 'must not match prefixed terms' do
+        assert_raises Parslet::ParseFailed do
+          subject.term.parse('cm3')[:term]
+        end
+      end
+
+      it 'must match exponential atoms' do
+        match = subject.term.parse('m3')[:term]
+        match[:atom][:atom_code].must_equal 'm'
+        match[:exponent][:integer].must_equal '3'
+      end
+
+      it 'must match factors' do
+        subject.term.parse('3.2')[:term][:factor][:fixnum].must_equal '3.2'
+      end
+
+      it 'must match annotations' do
+        match = subject.term.parse('N{Normal}')[:term]
+        match[:atom][:atom_code].must_equal 'N'
+        match[:annotation].must_equal 'Normal'
+      end
+    end
+
+    describe '#group' do
+      it 'must not match prefixed term within parentheses' do
+        assert_raises Parslet::ParseFailed do
+          subject.term.parse('(kg)')
+        end
+      end
+
+      it 'must match parentheses with a term' do
+        match = subject.group.parse('(s2)')[:group][:nested][:left][:term]
+        match[:atom][:atom_code].must_equal 's'
+        match[:exponent][:integer].must_equal '2'
+      end
+
+      it 'must not match nested groups with prefix' do
+        assert_raises Parslet::ParseFailed do
+          subject.term.parse('((kg))')
+        end
+      end
+
+      it 'must match nested groups' do
+        match = subject.group.parse('((g))')[:group][:nested][:left][:group][:nested][:left][:term]
+        match[:atom][:atom_code].must_equal 'g'
+      end
+
+      it 'must pass exponents down' do
+        match = subject.group.parse('([in_i])3')[:group]
+        match[:exponent][:integer].must_equal '3'
+        match[:nested][:left][:term][:atom][:atom_code].must_equal '[in_i]'
+      end
+
+      it 'must not match prefixed terms with exponents' do
+        assert_raises Parslet::ParseFailed do
+          subject.term.parse('kg2')
+        end
+      end
+    end
+
+    describe '#expression' do
+      it 'must not match prefixed expressions' do
+        assert_raises Parslet::ParseFailed do
+          subject.term.parse('ft/s')
+        end
+
+        assert_raises Parslet::ParseFailed do
+          subject.term.parse('km/s')
+        end
+      end
+
+      it 'must match left only' do
+        match = subject.expression.parse('m')
+        match[:left][:term][:atom][:atom_code].must_equal('m')
+      end
+
+      it 'must match left + right + operator' do
+        match = subject.expression.parse('m.s')
+        match[:left][:term][:atom][:atom_code].must_equal('m')
+        match[:operator].must_equal('.')
+        match[:right][:left][:term][:atom][:atom_code].must_equal('s')
+      end
+
+      it 'must match operator + right' do
+        match = subject.expression.parse('/s')
+        match[:operator].must_equal('/')
+        match[:right][:left][:term][:atom][:atom_code].must_equal('s')
+      end
+    end
+  end
+
+  describe 'when parser is initialized with :symbol as key' do
+    subject { Unitwise::Expression::AtomicParser.new(:symbol) }
+
+    describe '#metric_atom' do
+      it "must match 'N'" do
+        subject.metric_atom.parse('N')[:atom_code].must_equal('N')
+      end
+    end
+
+    describe '#atom' do
+      it "must match 'in'" do
+        subject.atom.parse('in')[:atom_code].must_equal('in')
+      end
+
+      it "must match 'ft'" do
+        subject.atom.parse('ft')[:atom_code].must_equal('ft')
+      end
+    end
+
+    describe '#expression' do
+      it 'must match left only' do
+        match = subject.expression.parse('ft')
+        match[:left][:term][:atom][:atom_code].must_equal('ft')
+      end
+
+      it 'must match left + right + operator' do
+        match = subject.expression.parse('ft.s')
+        match[:left][:term][:atom][:atom_code].must_equal('ft')
+        match[:operator].must_equal('.')
+        match[:right][:left][:term][:atom][:atom_code].must_equal('s')
+      end
+
+      it 'must match operator + right' do
+        match = subject.expression.parse('/s')
+        match[:operator].must_equal('/')
+        match[:right][:left][:term][:atom][:atom_code].must_equal('s')
+      end
+    end
+  end
+end

--- a/test/unitwise/expression/decomposer_test.rb
+++ b/test/unitwise/expression/decomposer_test.rb
@@ -1,45 +1,78 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 describe Unitwise::Expression::Decomposer do
   subject { Unitwise::Expression::Decomposer }
 
-  describe "#terms" do
-    it "should accept codes" do
-      fts = subject.new("[ft_i]/s").terms
+  describe '#terms' do
+    it 'should accept codes' do
+      fts = subject.new('[ft_i]/s').terms
       fts.count.must_equal 2
     end
-    it "should accept names" do
-      kms = subject.new("kilometer/second").terms
+
+    it 'should accept names' do
+      kms = subject.new('kilometer/second').terms
       kms.count.must_equal 2
     end
-    it "should accept spaced names" do
-      ncg = subject.new("Newtonian constant of gravitation").terms
+
+    it 'should accept spaced names' do
+      ncg = subject.new('Newtonian constant of gravitation').terms
       ncg.count.must_equal 1
     end
-    it "should accept parameterized names" do
-      pc = subject.new("planck_constant").terms
+
+    it 'should accept parameterized names' do
+      pc = subject.new('planck_constant').terms
       pc.count.must_equal 1
     end
-    it "should accept symbols" do
-      saff = subject.new("<i>g<sub>n</sub></i>").terms
+
+    it 'should accept symbols' do
+      saff = subject.new('<i>g<sub>n</sub></i>').terms
       saff.count.must_equal 1
     end
-    it "should accept complex units" do
-      complex = subject.new("(mg.(km/s)3/J)2.Pa").terms
+
+    it 'should accept exact symbol match over prefixed matches' do
+      ft = subject.new('ft').terms
+      ft.count.must_equal 1
+      ft.first.atom.primary_code.must_equal '[ft_i]'
+    end
+
+    it 'should accept prefixed units' do
+      kg = subject.new('kg').terms
+      kg.count.must_equal 1
+      kg.first.prefix.primary_code.must_equal 'k'
+    end
+
+    it 'should accept complex units' do
+      complex = subject.new('(mg.(km/s)3/J)2.Pa').terms
       complex.count.must_equal 5
     end
-    it "should accept more complex units" do
-      complex = subject.new("4.1(mm/2s3)4.7.3J-2").terms
+
+    it 'should accept complex units with symbol match over prefixed match' do
+      complex = subject.new('((ft/s)3/J)2.Pa').terms
+      complex.count.must_equal 4
+      complex.first.atom.primary_code.must_equal '[ft_i]'
+    end
+
+    it 'should accept more complex units' do
+      complex = subject.new('4.1(mm/2s3)4.7.3J-2').terms
       complex.count.must_equal 3
     end
-    it "should accept weird units" do
-      frequency = subject.new("/s").terms
+
+    it 'should accept weird units' do
+      frequency = subject.new('/s').terms
       frequency.count.must_equal 1
     end
-    it "should accept units with a factor and unit" do
-      oddity = subject.new("2ms2").terms
+
+    it 'should accept weird exact symbol match units over prefixed match' do
+      per_foot = subject.new('/ft').terms
+      per_foot.count.must_equal 1
+      per_foot.first.atom.primary_code.must_equal '[ft_i]'
+    end
+
+    it 'should accept units with a factor and unit' do
+      oddity = subject.new('2ms2').terms
       oddity.count.must_equal 1
     end
   end
-
 end

--- a/test/unitwise/expression/parser_test.rb
+++ b/test/unitwise/expression/parser_test.rb
@@ -1,109 +1,174 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 describe Unitwise::Expression::Parser do
-  subject { Unitwise::Expression::Parser.new}
-  describe '#metric_atom' do
-    it "must match 'N'" do
-      subject.metric_atom.parse('N')[:atom_code].must_equal('N')
+  describe "when parser is initialized with :primary_code as key" do
+    subject { Unitwise::Expression::Parser.new }
+
+    describe '#metric_atom' do
+      it "must match 'N'" do
+        subject.metric_atom.parse('N')[:atom_code].must_equal('N')
+      end
+
+      it "must match 't'" do
+        subject.atom.parse('t')[:atom_code].must_equal('t')
+      end
+    end
+
+    describe '#atom' do
+      it "must match '[in_i]'" do
+        subject.atom.parse('[in_i]')[:atom_code].must_equal('[in_i]')
+      end
+
+      it "must match '[ft_i]'" do
+        subject.atom.parse('[ft_i]')[:atom_code].must_equal('[ft_i]')
+      end
+    end
+
+    describe '#prefix' do
+      it "must match 'k'" do
+        subject.prefix.parse('k')[:prefix_code].must_equal('k')
+      end
+
+      it "must match 'f'" do
+        subject.prefix.parse('f')[:prefix_code].must_equal('f')
+      end
+    end
+
+    describe '#annotation' do
+      it "must match '{foobar}'" do
+        subject.annotation.parse('{foobar}')[:annotation].must_equal('foobar')
+      end
+    end
+
+    describe "#factor" do
+      it "must match positives and fixnums" do
+        subject.factor.parse('3.2')[:factor].must_equal(:fixnum => '3.2')
+      end
+
+      it "must match negatives and integers" do
+        subject.factor.parse('-5')[:factor].must_equal(:integer => '-5')
+      end
+    end
+
+    describe "#exponent" do
+      it "must match positives integers" do
+        subject.exponent.parse('4')[:exponent].must_equal(:integer => '4')
+      end
+
+      it "must match negative integers" do
+        subject.exponent.parse('-5')[:exponent].must_equal(:integer => '-5')
+      end
+    end
+
+    describe "term" do
+      it "must match basic atoms" do
+        subject.term.parse('[in_i]')[:term][:atom][:atom_code].must_equal('[in_i]')
+      end
+
+      it "must match prefixed atoms" do
+        match = subject.term.parse('ks')[:term]
+        match[:atom][:atom_code].must_equal('s')
+        match[:prefix][:prefix_code].must_equal('k')
+      end
+
+      it "must match exponential atoms" do
+        match = subject.term.parse('cm3')[:term]
+        match[:atom][:atom_code].must_equal 'm'
+        match[:prefix][:prefix_code].must_equal 'c'
+        match[:exponent][:integer].must_equal '3'
+      end
+
+      it "must match factors" do
+        subject.term.parse('3.2')[:term][:factor][:fixnum].must_equal '3.2'
+      end
+
+      it "must match annotations" do
+        match = subject.term.parse('N{Normal}')[:term]
+        match[:atom][:atom_code].must_equal 'N'
+        match[:annotation].must_equal 'Normal'
+      end
+    end
+
+    describe '#group' do
+      it "must match parentheses with a term" do
+        match = subject.group.parse('(s2)')[:group][:nested][:left][:term]
+        match[:atom][:atom_code].must_equal 's'
+        match[:exponent][:integer].must_equal '2'
+      end
+
+      it "must match nested groups" do
+        match = subject.group.parse('((kg))')[:group][:nested][:left][:group][:nested][:left][:term]
+        match[:atom][:atom_code].must_equal 'g'
+        match[:prefix][:prefix_code].must_equal 'k'
+      end
+
+      it "must pass exponents down" do
+        match = subject.group.parse('([in_i])3')[:group]
+        match[:exponent][:integer].must_equal '3'
+        match[:nested][:left][:term][:atom][:atom_code].must_equal '[in_i]'
+      end
+    end
+
+    describe "#expression" do
+      it "must match left only" do
+        match = subject.expression.parse('m')
+        match[:left][:term][:atom][:atom_code].must_equal("m")
+      end
+
+      it "must match left + right + operator" do
+        match = subject.expression.parse('m.s')
+        match[:left][:term][:atom][:atom_code].must_equal("m")
+        match[:operator].must_equal('.')
+        match[:right][:left][:term][:atom][:atom_code].must_equal('s')
+      end
+
+      it "must match operator + right" do
+        match = subject.expression.parse("/s")
+        match[:operator].must_equal('/')
+        match[:right][:left][:term][:atom][:atom_code].must_equal('s')
+      end
     end
   end
 
-  describe '#atom' do
-    it "must match '[in_i]'" do
-      subject.atom.parse('[in_i]')[:atom_code].must_equal('[in_i]')
+  describe "when parser is initialized with :names as key" do
+    subject { Unitwise::Expression::Parser.new(:names) }
+
+    describe '#metric_atom' do
+      it "must match 'newton'" do
+        subject.metric_atom.parse('newton')[:atom_code].must_equal('newton')
+      end
+    end
+
+    describe '#atom' do
+      it "must match 'inch'" do
+        subject.atom.parse('inch')[:atom_code].must_equal('inch')
+      end
+
+      it "must match 'foot'" do
+        subject.atom.parse('foot')[:atom_code].must_equal('foot')
+      end
     end
   end
 
-  describe '#prefix' do
-    it "must match 'k'" do
-      subject.prefix.parse('k')[:prefix_code].must_equal('k')
+  describe "when parser is initialized with :symbol as key" do
+    subject { Unitwise::Expression::Parser.new(:symbol) }
+
+    describe '#metric_atom' do
+      it "must match 'N'" do
+        subject.metric_atom.parse('N')[:atom_code].must_equal('N')
+      end
+    end
+
+    describe '#atom' do
+      it "must match 'in'" do
+        subject.atom.parse('in')[:atom_code].must_equal('in')
+      end
+
+      it "must match 'ft'" do
+        subject.atom.parse('ft')[:atom_code].must_equal('ft')
+      end
     end
   end
-
-  describe '#annotation' do
-    it "must match '{foobar}'" do
-      subject.annotation.parse('{foobar}')[:annotation].must_equal('foobar')
-    end
-  end
-
-  describe "#factor" do
-    it "must match positives and fixnums" do
-      subject.factor.parse('3.2')[:factor].must_equal(:fixnum => '3.2')
-    end
-    it "must match negatives and integers" do
-      subject.factor.parse('-5')[:factor].must_equal(:integer => '-5')
-    end
-  end
-
-  describe "#exponent" do
-    it "must match positives integers" do
-      subject.exponent.parse('4')[:exponent].must_equal(:integer => '4')
-    end
-    it "must match negative integers" do
-      subject.exponent.parse('-5')[:exponent].must_equal(:integer => '-5')
-    end
-  end
-
-  describe "term" do
-    it "must match basic atoms" do
-      subject.term.parse('[in_i]')[:term][:atom][:atom_code].must_equal('[in_i]')
-    end
-    it "must match prefixed atoms" do
-      match = subject.term.parse('ks')[:term]
-      match[:atom][:atom_code].must_equal('s')
-      match[:prefix][:prefix_code].must_equal('k')
-    end
-    it "must match exponential atoms" do
-      match = subject.term.parse('cm3')[:term]
-      match[:atom][:atom_code].must_equal 'm'
-      match[:prefix][:prefix_code].must_equal 'c'
-      match[:exponent][:integer].must_equal '3'
-    end
-    it "must match factors" do
-      subject.term.parse('3.2')[:term][:factor][:fixnum].must_equal '3.2'
-    end
-    it "must match annotations" do
-      match = subject.term.parse('N{Normal}')[:term]
-      match[:atom][:atom_code].must_equal 'N'
-      match[:annotation].must_equal 'Normal'
-    end
-  end
-
-  describe '#group' do
-    it "must match parentheses with a term" do
-      match = subject.group.parse('(s2)')[:group][:nested][:left][:term]
-      match[:atom][:atom_code].must_equal 's'
-      match[:exponent][:integer].must_equal '2'
-    end
-    it "must match nested groups" do
-      match = subject.group.parse('((kg))')[:group][:nested][:left][:group][:nested][:left][:term]
-      match[:atom][:atom_code].must_equal 'g'
-      match[:prefix][:prefix_code].must_equal 'k'
-    end
-    it "must pass exponents down" do
-      match = subject.group.parse('([in_i])3')[:group]
-      match[:exponent][:integer].must_equal '3'
-      match[:nested][:left][:term][:atom][:atom_code].must_equal '[in_i]'
-    end
-  end
-
-  describe "#expression" do
-    it "must match left only" do
-      match = subject.expression.parse('m')
-      match[:left][:term][:atom][:atom_code].must_equal("m")
-    end
-    it "must match left + right + operator" do
-      match = subject.expression.parse('m.s')
-      match[:left][:term][:atom][:atom_code].must_equal("m")
-      match[:operator].must_equal('.')
-      match[:right][:left][:term][:atom][:atom_code].must_equal('s')
-    end
-    it "must match operator + right" do
-      match = subject.expression.parse("/s")
-      match[:operator].must_equal('/')
-      match[:right][:left][:term][:atom][:atom_code].must_equal('s')
-    end
-  end
-
-
 end


### PR DESCRIPTION
Hi, first of all I'd like to thank you for making this fantastic gem. I've been trialing this gem for basic unit conversions, and it's worked out great for me so far.

Because I'm using this gem for basic unit parsing, I had the same issue as #16, where parsing `'ft'` gave me back `femto tonne` instead of the desired unit `foot`. This PR is intended to change that so exact atomic unit matches are prioritised over prefixed matches. 

Obviously this breaks the original parsing precedence of metric > rest, and may not be what you desire. Maybe we can add a configuration object for toggling the parsing precedence?

