### PR TITLE
Fixes `minitest` deprecation warnings

### DIFF
--- a/test/support/scale_tests.rb
+++ b/test/support/scale_tests.rb
@@ -16,94 +16,94 @@ module ScaleTests
 
       describe "#new" do
         it "must set attributes" do
-          subject.value.must_equal(4)
-          subject.unit.to_s.must_equal('J')
+          _(subject.value).must_equal(4)
+          _(subject.unit.to_s).must_equal('J')
         end
       end
 
       describe "#unit" do
         it "must be a unit" do
-          subject.must_respond_to(:unit)
-          subject.unit.must_be_instance_of(Unitwise::Unit)
+          _(subject).must_respond_to(:unit)
+          _(subject.unit).must_be_instance_of(Unitwise::Unit)
         end
       end
 
       describe "#root_terms" do
         it "must be a collection of terms" do
-          subject.must_respond_to(:root_terms)
-          subject.root_terms.must_be_kind_of Enumerable
-          subject.root_terms.first.must_be_instance_of(Unitwise::Term)
+          _(subject).must_respond_to(:root_terms)
+          _(subject.root_terms).must_be_kind_of Enumerable
+          _(subject.root_terms.first).must_be_instance_of(Unitwise::Term)
         end
       end
 
       describe "#terms" do
         it "must return an array of terms" do
-          subject.terms.must_be_kind_of(Enumerable)
-          subject.terms.first.must_be_kind_of(Unitwise::Term)
+          _(subject.terms).must_be_kind_of(Enumerable)
+          _(subject.terms.first).must_be_kind_of(Unitwise::Term)
         end
       end
 
       describe "#atoms" do
         it "must return an array of atoms" do
-          subject.atoms.must_be_kind_of(Enumerable)
-          subject.atoms.first.must_be_kind_of(Unitwise::Atom)
+          _(subject.atoms).must_be_kind_of(Enumerable)
+          _(subject.atoms.first).must_be_kind_of(Unitwise::Atom)
         end
       end
 
       describe "#scalar" do
         it "must return value relative to terminal atoms" do
-          subject.scalar.must_equal 4000
-          mph.scalar.must_almost_equal 26.8224
-          cel.scalar.must_equal 295.15
+          _(subject.scalar).must_equal 4000
+          _(mph.scalar).must_almost_equal 26.8224
+          _(cel.scalar).must_equal 295.15
         end
       end
 
       describe "#magnitude" do
         it "must return the magnitude" do
-          mph.magnitude.must_equal(60)
-          cel.magnitude.must_equal(22)
+          _(mph.magnitude).must_equal(60)
+          _(cel.magnitude).must_equal(22)
         end
       end
 
       describe "#special?" do
         it "must return true when unit is special, false otherwise" do
-          subject.special?.must_equal false
-          cel.special?.must_equal true
+          _(subject.special?).must_equal false
+          _(cel.special?).must_equal true
         end
       end
 
       describe "#depth" do
         it "must return a number indicating how far down the rabbit hole goes" do
-          subject.depth.must_equal 11
-          k.depth.must_equal 3
+          _(subject.depth).must_equal 11
+          _(k.depth).must_equal 3
         end
       end
 
       describe "#frozen?" do
         it "must be frozen" do
-          subject.frozen?.must_equal true
+          _(subject.frozen?).must_equal true
         end
       end
 
       describe "#simplified_value" do
         it "must simplify to an Integer" do
           result = described_class.new(4.0, 'foot').simplified_value
-          result.must_equal 4
-          result.must_be_kind_of(Integer)
+          _(result).must_equal 4
+          _(result).must_be_kind_of(Integer)
         end
 
         it "must simplify to a Float" do
           result = described_class.new(BigDecimal("1.5"), 'foot').simplified_value
-          result.must_equal 1.5
-          result.must_be_kind_of(Float)
+          _(result).must_equal 1.5
+          _(result).must_be_kind_of(Float)
         end
       end
 
       describe "#inspect" do
         it "must show the unit and value" do
           result = described_class.new(12, 'meter').inspect
-          result.must_include("value=12")
-          result.must_include("unit=meter")
+          _(result).must_include("value=12")
+          _(result).must_include("unit=meter")
         end
       end
     end

--- a/test/unitwise/atom_test.rb
+++ b/test/unitwise/atom_test.rb
@@ -4,22 +4,22 @@ describe Unitwise::Atom do
   subject { Unitwise::Atom }
   describe "::data" do
     it "must have data" do
-      subject.data.must_be_instance_of Array
-      subject.data.count.must_be :>, 0
+      _(subject.data).must_be_instance_of Array
+      _(subject.data.count).must_be :>, 0
     end
   end
 
   describe "::all" do
     it "must be an Array of instances" do
-      subject.all.must_be_instance_of Array
-      subject.all.first.must_be_instance_of Unitwise::Atom
+      _(subject.all).must_be_instance_of Array
+      _(subject.all.first).must_be_instance_of Unitwise::Atom
     end
   end
 
   describe "::find" do
     it "must find atoms" do
-      subject.find("m").must_be_instance_of Unitwise::Atom
-      subject.find("V").must_be_instance_of Unitwise::Atom
+      _(subject.find("m")).must_be_instance_of Unitwise::Atom
+      _(subject.find("V")).must_be_instance_of Unitwise::Atom
     end
   end
 
@@ -31,87 +31,87 @@ describe Unitwise::Atom do
   let(:joule)   { Unitwise::Atom.find("J")}
   describe "#scale" do
     it "must be nil for base atoms" do
-      second.scale.must_be_nil
+      _(second.scale).must_be_nil
     end
     it "sould be a Scale object for derived atoms" do
-      yard.scale.must_be_instance_of Unitwise::Scale
+      _(yard.scale).must_be_instance_of Unitwise::Scale
     end
     it "must be a FunctionalScale object for special atoms" do
-      celsius.scale.must_be_instance_of Unitwise::Functional
+      _(celsius.scale).must_be_instance_of Unitwise::Functional
     end
   end
 
   describe "#base?" do
     it "must be true for base atoms" do
-      second.base?.must_equal true
+      _(second.base?).must_equal true
     end
     it "must be false for derived atoms" do
-      yard.base?.must_equal false
-      pi.base?.must_equal false
+      _(yard.base?).must_equal false
+      _(pi.base?).must_equal false
     end
   end
 
   describe "#derived?" do
     it "must be false for base atoms" do
-      second.derived?.must_equal false
+      _(second.derived?).must_equal false
     end
     it "must be true for derived atoms" do
-      yard.derived?.must_equal true
-      celsius.derived?.must_equal true
+      _(yard.derived?).must_equal true
+      _(celsius.derived?).must_equal true
     end
   end
 
   describe "#metric?" do
     it "must be true for base atoms" do
-      second.metric?.must_equal true
+      _(second.metric?).must_equal true
     end
     it "must be false for english atoms" do
-      yard.metric?.must_equal false
+      _(yard.metric?).must_equal false
     end
   end
 
   describe "#special?" do
     it "must be true for special atoms" do
-      celsius.special?.must_equal true
+      _(celsius.special?).must_equal true
     end
     it "must be false for non-special atoms" do
-      second.special?.must_equal false
+      _(second.special?).must_equal false
     end
   end
 
   describe "#arbitrary?" do
     it "must be true for arbitrary atoms" do
-      pfu.arbitrary?.must_equal true
+      _(pfu.arbitrary?).must_equal true
     end
     it "must be false for non-arbitrary atoms" do
-      yard.arbitrary?.must_equal false
-      celsius.arbitrary?.must_equal false
+      _(yard.arbitrary?).must_equal false
+      _(celsius.arbitrary?).must_equal false
     end
   end
 
   describe "#terminal?" do
     it "must be true for atoms without a valid measurement atom" do
-      second.terminal?.must_equal true
-      pi.terminal?.must_equal true
+      _(second.terminal?).must_equal true
+      _(pi.terminal?).must_equal true
     end
     it "must be false for child atoms" do
-      yard.terminal?.must_equal false
+      _(yard.terminal?).must_equal false
     end
   end
 
   describe "#scalar" do
     it "must return scalar relative to terminal atom" do
-      second.scalar.must_equal 1
-      yard.scalar.must_almost_equal 0.9144
-      pi.scalar.must_almost_equal 3.141592653589793
+      _(second.scalar).must_equal 1
+      _(yard.scalar).must_almost_equal 0.9144
+      _(pi.scalar).must_almost_equal 3.141592653589793
     end
   end
 
   describe "#dim" do
     it "must return the dim" do
-      second.dim.must_equal 'T'
-      yard.dim.must_equal 'L'
-      joule.dim.must_equal 'L2.M.T-2'
+      _(second.dim).must_equal 'T'
+      _(yard.dim).must_equal 'L'
+      _(joule.dim).must_equal 'L2.M.T-2'
     end
   end
 
@@ -123,7 +123,7 @@ describe Unitwise::Atom do
 
   describe "#frozen?" do
     it "should be frozen" do
-      second.frozen?.must_equal true
+      _(second.frozen?).must_equal true
     end
   end
 
@@ -139,7 +139,7 @@ describe Unitwise::Atom do
         }
       )
 
-      atom.validate!.must_equal true
+      _(atom.validate!).must_equal true
     end
 
     it "returns an error for an atom with missing properties" do

--- a/test/unitwise/expression/decomposer_test.rb
+++ b/test/unitwise/expression/decomposer_test.rb
@@ -6,39 +6,39 @@ describe Unitwise::Expression::Decomposer do
   describe "#terms" do
     it "should accept codes" do
       fts = subject.new("[ft_i]/s").terms
-      fts.count.must_equal 2
+      _(fts.count).must_equal 2
     end
     it "should accept names" do
       kms = subject.new("kilometer/second").terms
-      kms.count.must_equal 2
+      _(kms.count).must_equal 2
     end
     it "should accept spaced names" do
       ncg = subject.new("Newtonian constant of gravitation").terms
-      ncg.count.must_equal 1
+      _(ncg.count).must_equal 1
     end
     it "should accept parameterized names" do
       pc = subject.new("planck_constant").terms
-      pc.count.must_equal 1
+      _(pc.count).must_equal 1
     end
     it "should accept symbols" do
       saff = subject.new("<i>g<sub>n</sub></i>").terms
-      saff.count.must_equal 1
+      _(saff.count).must_equal 1
     end
     it "should accept complex units" do
       complex = subject.new("(mg.(km/s)3/J)2.Pa").terms
-      complex.count.must_equal 5
+      _(complex.count).must_equal 5
     end
     it "should accept more complex units" do
       complex = subject.new("4.1(mm/2s3)4.7.3J-2").terms
-      complex.count.must_equal 3
+      _(complex.count).must_equal 3
     end
     it "should accept weird units" do
       frequency = subject.new("/s").terms
-      frequency.count.must_equal 1
+      _(frequency.count).must_equal 1
     end
     it "should accept units with a factor and unit" do
       oddity = subject.new("2ms2").terms
-      oddity.count.must_equal 1
+      _(oddity.count).must_equal 1
     end
   end
 

--- a/test/unitwise/expression/matcher_test.rb
+++ b/test/unitwise/expression/matcher_test.rb
@@ -4,39 +4,39 @@ describe Unitwise::Expression::Matcher do
   describe "::atom(:codes)" do
     subject { Unitwise::Expression::Matcher.atom(:primary_code)}
     it "must be an Alternative list" do
-      subject.must_be_instance_of Parslet::Atoms::Alternative
+      _(subject).must_be_instance_of Parslet::Atoms::Alternative
     end
     it "must parse [in_i]" do
-      subject.parse("[in_i]").must_equal("[in_i]")
+      _(subject.parse("[in_i]")).must_equal("[in_i]")
     end
   end
   describe "::metric_atom(:names)" do
     subject { Unitwise::Expression::Matcher.metric_atom(:names)}
     it "must be an Alternative list of names" do
-      subject.must_be_instance_of Parslet::Atoms::Alternative
+      _(subject).must_be_instance_of Parslet::Atoms::Alternative
     end
     it "must parse 'joule'" do
-      subject.parse('joule').must_equal('joule')
+      _(subject.parse('joule')).must_equal('joule')
     end
   end
 
   describe "::atom(:slugs)" do
     subject { Unitwise::Expression::Matcher.atom(:slugs)}
     it "must be an Alternative list of slugs" do
-      subject.must_be_instance_of Parslet::Atoms::Alternative
+      _(subject).must_be_instance_of Parslet::Atoms::Alternative
     end
     it "must match 'georgian_year'" do
-      subject.parse("mean_gregorian_year").must_equal("mean_gregorian_year")
+      _(subject.parse("mean_gregorian_year")).must_equal("mean_gregorian_year")
     end
   end
 
   describe "::prefix(:symbol)" do
     subject { Unitwise::Expression::Matcher.prefix(:symbol)}
     it "must be an Alternative list of symbols" do
-      subject.must_be_instance_of Parslet::Atoms::Alternative
+      _(subject).must_be_instance_of Parslet::Atoms::Alternative
     end
     it "must parse 'h'" do
-      subject.parse('h').must_equal('h')
+      _(subject.parse('h')).must_equal('h')
     end
   end
 end

--- a/test/unitwise/expression/parser_test.rb
+++ b/test/unitwise/expression/parser_test.rb
@@ -4,104 +4,104 @@ describe Unitwise::Expression::Parser do
   subject { Unitwise::Expression::Parser.new}
   describe '#metric_atom' do
     it "must match 'N'" do
-      subject.metric_atom.parse('N')[:atom_code].must_equal('N')
+      _(subject.metric_atom.parse('N')[:atom_code]).must_equal('N')
     end
   end
 
   describe '#atom' do
     it "must match '[in_i]'" do
-      subject.atom.parse('[in_i]')[:atom_code].must_equal('[in_i]')
+      _(subject.atom.parse('[in_i]')[:atom_code]).must_equal('[in_i]')
     end
   end
 
   describe '#prefix' do
     it "must match 'k'" do
-      subject.prefix.parse('k')[:prefix_code].must_equal('k')
+      _(subject.prefix.parse('k')[:prefix_code]).must_equal('k')
     end
   end
 
   describe '#annotation' do
     it "must match '{foobar}'" do
-      subject.annotation.parse('{foobar}')[:annotation].must_equal('foobar')
+      _(subject.annotation.parse('{foobar}')[:annotation]).must_equal('foobar')
     end
   end
 
   describe "#factor" do
     it "must match positives and fixnums" do
-      subject.factor.parse('3.2')[:factor].must_equal(:fixnum => '3.2')
+      _(subject.factor.parse('3.2')[:factor]).must_equal(:fixnum => '3.2')
     end
     it "must match negatives and integers" do
-      subject.factor.parse('-5')[:factor].must_equal(:integer => '-5')
+      _(subject.factor.parse('-5')[:factor]).must_equal(:integer => '-5')
     end
   end
 
   describe "#exponent" do
     it "must match positives integers" do
-      subject.exponent.parse('4')[:exponent].must_equal(:integer => '4')
+      _(subject.exponent.parse('4')[:exponent]).must_equal(:integer => '4')
     end
     it "must match negative integers" do
-      subject.exponent.parse('-5')[:exponent].must_equal(:integer => '-5')
+      _(subject.exponent.parse('-5')[:exponent]).must_equal(:integer => '-5')
     end
   end
 
   describe "term" do
     it "must match basic atoms" do
-      subject.term.parse('[in_i]')[:term][:atom][:atom_code].must_equal('[in_i]')
+      _(subject.term.parse('[in_i]')[:term][:atom][:atom_code]).must_equal('[in_i]')
     end
     it "must match prefixed atoms" do
       match = subject.term.parse('ks')[:term]
-      match[:atom][:atom_code].must_equal('s')
-      match[:prefix][:prefix_code].must_equal('k')
+      _(match[:atom][:atom_code]).must_equal('s')
+      _(match[:prefix][:prefix_code]).must_equal('k')
     end
     it "must match exponential atoms" do
       match = subject.term.parse('cm3')[:term]
-      match[:atom][:atom_code].must_equal 'm'
-      match[:prefix][:prefix_code].must_equal 'c'
-      match[:exponent][:integer].must_equal '3'
+      _(match[:atom][:atom_code]).must_equal 'm'
+      _(match[:prefix][:prefix_code]).must_equal 'c'
+      _(match[:exponent][:integer]).must_equal '3'
     end
     it "must match factors" do
-      subject.term.parse('3.2')[:term][:factor][:fixnum].must_equal '3.2'
+      _(subject.term.parse('3.2')[:term][:factor][:fixnum]).must_equal '3.2'
     end
     it "must match annotations" do
       match = subject.term.parse('N{Normal}')[:term]
-      match[:atom][:atom_code].must_equal 'N'
-      match[:annotation].must_equal 'Normal'
+      _(match[:atom][:atom_code]).must_equal 'N'
+      _(match[:annotation]).must_equal 'Normal'
     end
   end
 
   describe '#group' do
     it "must match parentheses with a term" do
       match = subject.group.parse('(s2)')[:group][:nested][:left][:term]
-      match[:atom][:atom_code].must_equal 's'
-      match[:exponent][:integer].must_equal '2'
+      _(match[:atom][:atom_code]).must_equal 's'
+      _(match[:exponent][:integer]).must_equal '2'
     end
     it "must match nested groups" do
       match = subject.group.parse('((kg))')[:group][:nested][:left][:group][:nested][:left][:term]
-      match[:atom][:atom_code].must_equal 'g'
-      match[:prefix][:prefix_code].must_equal 'k'
+      _(match[:atom][:atom_code]).must_equal 'g'
+      _(match[:prefix][:prefix_code]).must_equal 'k'
     end
     it "must pass exponents down" do
       match = subject.group.parse('([in_i])3')[:group]
-      match[:exponent][:integer].must_equal '3'
-      match[:nested][:left][:term][:atom][:atom_code].must_equal '[in_i]'
+      _(match[:exponent][:integer]).must_equal '3'
+      _(match[:nested][:left][:term][:atom][:atom_code]).must_equal '[in_i]'
     end
   end
 
   describe "#expression" do
     it "must match left only" do
       match = subject.expression.parse('m')
-      match[:left][:term][:atom][:atom_code].must_equal("m")
+      _(match[:left][:term][:atom][:atom_code]).must_equal("m")
     end
     it "must match left + right + operator" do
       match = subject.expression.parse('m.s')
-      match[:left][:term][:atom][:atom_code].must_equal("m")
-      match[:operator].must_equal('.')
-      match[:right][:left][:term][:atom][:atom_code].must_equal('s')
+      _(match[:left][:term][:atom][:atom_code]).must_equal("m")
+      _(match[:operator]).must_equal('.')
+      _(match[:right][:left][:term][:atom][:atom_code]).must_equal('s')
     end
     it "must match operator + right" do
       match = subject.expression.parse("/s")
-      match[:operator].must_equal('/')
-      match[:right][:left][:term][:atom][:atom_code].must_equal('s')
+      _(match[:operator]).must_equal('/')
+      _(match[:right][:left][:term][:atom][:atom_code]).must_equal('s')
     end
   end
 

--- a/test/unitwise/functional_test.rb
+++ b/test/unitwise/functional_test.rb
@@ -9,7 +9,7 @@ describe Unitwise::Functional do
         there = subject.send "to_#{function}", number
         back_again = subject.send "from_#{function}", there
         rounded_result = (back_again * 1000).round / 1000.0
-        rounded_result.must_equal number
+        _(rounded_result).must_equal number
       end
     end
   end

--- a/test/unitwise/measurement_test.rb
+++ b/test/unitwise/measurement_test.rb
@@ -8,90 +8,90 @@ describe Unitwise::Measurement do
 
   describe "#new" do
     it "should raise an error for unknown units" do
-      lambda { Unitwise::Measurement.new(1,"funkitron") }.must_raise(Unitwise::ExpressionError)
+      _{ Unitwise::Measurement.new(1,"funkitron") }.must_raise(Unitwise::ExpressionError)
     end
   end
 
   describe "#convert_to" do
     it "must convert to a similar unit code" do
-      mph.convert_to('km/h').value.must_almost_equal(96.56063)
+      _(mph.convert_to('km/h').value).must_almost_equal(96.56063)
     end
     it "must raise an error if the units aren't similar" do
-      lambda { mph.convert_to('N') }.must_raise Unitwise::ConversionError
+      _{ mph.convert_to('N') }.must_raise Unitwise::ConversionError
     end
     it "must convert special units to their base units" do
-      cel.convert_to('K').value.must_equal 295.15
+      _(cel.convert_to('K').value).must_equal 295.15
     end
     it "must convert base units to special units" do
-      k.convert_to('Cel').value.must_equal 100
+      _(k.convert_to('Cel').value).must_equal 100
     end
     it "must convert special units to special units" do
-      f.convert_to('Cel').value.must_almost_equal 37
+      _(f.convert_to('Cel').value).must_almost_equal 37
     end
     it "must convert special units to non-special units" do
-      cel.convert_to("[degR]").value.must_almost_equal(531.27)
+      _(cel.convert_to("[degR]").value).must_almost_equal(531.27)
     end
     it "must convert derived units to special units" do
-      r.convert_to("Cel").value.must_almost_equal(0)
+      _(r.convert_to("Cel").value).must_almost_equal(0)
     end
     it "must convert to a unit of another measurement" do
-      mph.convert_to(kmh).value.must_almost_equal(96.56064)
+      _(mph.convert_to(kmh).value).must_almost_equal(96.56064)
     end
     it "must convert to and from another unit without losing precision" do
       circle = Unitwise::Measurement.new(1, "circle")
-      circle.to_degree.to_circle.must_equal circle
+      _(circle.to_degree.to_circle).must_equal circle
 
       meter = Unitwise::Measurement.new(10, "meter")
-      meter.to_mile.to_meter.must_equal meter
+      _(meter.to_mile.to_meter).must_equal meter
     end
   end
 
   describe "#*" do
     it "must multiply by scalars" do
       mult = mph * 4
-      mult.value.must_equal 240
-      mult.unit.must_equal Unitwise::Unit.new("[mi_i]/h")
+      _(mult.value).must_equal 240
+      _(mult.unit).must_equal Unitwise::Unit.new("[mi_i]/h")
     end
     it "must multiply similar units" do
       mult = mph * kmh
-      mult.value.must_almost_equal 3728.22715342
-      mult.unit.must_equal Unitwise::Unit.new("([mi_i]/h).([mi_i]/h)")
+      _(mult.value).must_almost_equal 3728.22715342
+      _(mult.unit).must_equal Unitwise::Unit.new("([mi_i]/h).([mi_i]/h)")
     end
     it "must multiply unsimilar units" do
       mult = mph * mile
-      mult.value.must_equal 180
-      mult.unit.must_equal Unitwise::Unit.new("[mi_i]2/h")
+      _(mult.value).must_equal 180
+      _(mult.unit).must_equal Unitwise::Unit.new("[mi_i]2/h")
     end
     it "must multiply canceling units" do
       mult = mph * hpm
-      mult.value.must_equal 360
-      mult.unit.to_s.must_equal "1"
+      _(mult.value).must_equal 360
+      _(mult.unit.to_s).must_equal "1"
     end
   end
 
   describe "#/" do
     it "must divide by scalars" do
       div = kmh / 4
-      div.value.must_equal 25
-      div.unit.must_equal kmh.unit
+      _(div.value).must_equal 25
+      _(div.unit).must_equal kmh.unit
     end
     it "must divide by the value of similar units" do
       div = kmh / mph
-      div.value.must_almost_equal 1.03561865
-      div.unit.to_s.must_equal '1'
+      _(div.value).must_almost_equal 1.03561865
+      _(div.unit.to_s).must_equal '1'
     end
     it "must divide dissimilar units" do
       div = mph / hpm
-      div.value.must_equal 10
-      div.unit.to_s.must_equal "[mi_i]2/h2"
+      _(div.value).must_equal 10
+      _(div.unit.to_s).must_equal "[mi_i]2/h2"
     end
   end
 
   describe "#+" do
     it "must add values when units are similar" do
       added = mph + kmh
-      added.value.must_almost_equal 122.13711922
-      added.unit.must_equal mph.unit
+      _(added.value).must_almost_equal 122.13711922
+      _(added.unit).must_equal mph.unit
     end
     it "must raise an error when units are not similar" do
       assert_raises(TypeError) { mph + hpm}
@@ -101,8 +101,8 @@ describe Unitwise::Measurement do
   describe "#-" do
     it "must add values when units are similar" do
       added = mph - kmh
-      added.value.must_almost_equal(-2.1371192)
-      added.unit.must_equal mph.unit
+      _(added.value).must_almost_equal(-2.1371192)
+      _(added.unit).must_equal mph.unit
     end
     it "must raise an error when units are not similar" do
       assert_raises(TypeError) { mph - hpm}
@@ -112,26 +112,26 @@ describe Unitwise::Measurement do
   describe "#**" do
     it "must raise to a power" do
       exp = mile ** 3
-      exp.value.must_equal 27
-      exp.unit.to_s.must_equal "[mi_i]3"
+      _(exp.value).must_equal 27
+      _(exp.unit.to_s).must_equal "[mi_i]3"
     end
     it "must raise to a negative power" do
       exp = mile ** -3
-      exp.value.must_equal 0.037037037037037035
-      exp.unit.to_s.must_equal "1/[mi_i]3"
+      _(exp.value).must_equal 0.037037037037037035
+      _(exp.unit.to_s).must_equal "1/[mi_i]3"
     end
     it "must not raise to a weird power" do
-      lambda { mile ** 'weird' }.must_raise TypeError
+      _{ mile ** 'weird' }.must_raise TypeError
     end
   end
 
   describe "#coerce" do
     let(:meter) { Unitwise::Measurement.new(1, 'm') }
     it "must coerce numerics" do
-      (5 * meter).must_equal Unitwise::Measurement.new(5, 'm')
+      _((5 * meter)).must_equal Unitwise::Measurement.new(5, 'm')
     end
     it "should raise an error for other crap" do
-      lambda { meter.coerce("foo") }.must_raise TypeError
+      _{ meter.coerce("foo") }.must_raise TypeError
     end
   end
 
@@ -171,22 +171,22 @@ describe Unitwise::Measurement do
     let(:meter) { Unitwise::Measurement.new(1, 'm')}
     it "must convert 'to_mm'" do
       convert = meter.to_mm
-      convert.must_be_instance_of Unitwise::Measurement
-      convert.value.must_equal 1000
+      _(convert).must_be_instance_of Unitwise::Measurement
+      _(convert.value).must_equal 1000
     end
 
     it "must convert 'to_foot'" do
       convert = meter.to_foot
-      convert.must_be_instance_of Unitwise::Measurement
-      convert.value.must_almost_equal 3.280839895
+      _(convert).must_be_instance_of Unitwise::Measurement
+      _(convert.value).must_almost_equal 3.280839895
     end
 
     it "must not convert 'foo'" do
-      lambda { meter.foo }.must_raise NoMethodError
+      _{ meter.foo }.must_raise NoMethodError
     end
 
     it "must not convert 'to_foo'" do
-      lambda { meter.to_foo }.must_raise NoMethodError
+      _{ meter.to_foo }.must_raise NoMethodError
     end
 
   end
@@ -194,54 +194,54 @@ describe Unitwise::Measurement do
   describe "#round" do
     it "must round Floats to Integers" do
       result = Unitwise::Measurement.new(98.6, "[degF]").round
-      result.value.must_equal(99)
-      result.value.must_be_kind_of(Integer)
+      _(result.value).must_equal(99)
+      _(result.value).must_be_kind_of(Integer)
     end
     it "must round Floats to Floats" do
       if RUBY_VERSION > '1.8.7'
         result = Unitwise::Measurement.new(17.625, "J").round(2)
-        result.value.must_equal(17.63)
-        result.value.must_be_kind_of(Float)
+        _(result.value).must_equal(17.63)
+        _(result.value).must_be_kind_of(Float)
       end
     end
   end
   describe "#to_f" do
     it "must convert to a float" do
-      f.to_f.must_be_kind_of(Float)
+      _(f.to_f).must_be_kind_of(Float)
     end
   end
 
   describe "#to_i" do
     it "must convert to an integer" do
-      k.to_i.must_be_kind_of(Integer)
+      _(k.to_i).must_be_kind_of(Integer)
     end
   end
 
   describe "#to_r" do
     it "must convert to a rational" do
-      cel.to_r.must_be_kind_of(Rational)
+      _(cel.to_r).must_be_kind_of(Rational)
     end
   end
 
   describe "#to_s" do
     it "should include the simplified value and use the mode it was created with" do
       foot = described_class.new(7.00, "foot")
-      foot.to_s.must_equal "7 foot"
+      _(foot.to_s).must_equal "7 foot"
       meter = described_class.new(BigDecimal("3.142"), "m")
-      meter.to_s.must_equal("3.142 m")
+      _(meter.to_s).must_equal("3.142 m")
     end
     it "should accept a mode and print that mode string" do
       temp = described_class.new(25, "degree Celsius")
-      temp.to_s(:primary_code).must_equal("25 Cel")
-      temp.to_s(:symbol).must_equal("25 °C")
+      _(temp.to_s(:primary_code)).must_equal("25 Cel")
+      _(temp.to_s(:symbol)).must_equal("25 °C")
     end
     it "should fallback when there is no value for the provided mode" do
       vol = described_class.new(12, "teaspoon")
-      vol.to_s(:symbol).must_equal("12 [tsp_us]")
+      _(vol.to_s(:symbol)).must_equal("12 [tsp_us]")
     end
     it "should not return '1 1' for dimless measurements" do
       dimless = described_class.new(1, "1")
-      dimless.to_s.must_equal("1")
+      _(dimless.to_s).must_equal("1")
     end
   end
 

--- a/test/unitwise/prefix_test.rb
+++ b/test/unitwise/prefix_test.rb
@@ -5,20 +5,20 @@ describe Unitwise::Prefix do
   let(:m) { Unitwise::Prefix.find('m')}
   describe "::data" do
     it "should be an Array" do
-      subject.data.must_be_instance_of Array
+      _(subject.data).must_be_instance_of Array
     end
   end
 
   describe "::all" do
     it "should be an array of prefixes" do
-      subject.all.must_be_instance_of Array
-      subject.all.first.must_be_instance_of Unitwise::Prefix
+      _(subject.all).must_be_instance_of Array
+      _(subject.all.first).must_be_instance_of Unitwise::Prefix
     end
   end
 
   describe "#scalar" do
     it "should be a number" do
-      m.scalar.must_equal 0.001
+      _(m.scalar).must_equal 0.001
     end
   end
 

--- a/test/unitwise/search_test.rb
+++ b/test/unitwise/search_test.rb
@@ -4,14 +4,14 @@ describe Unitwise::Search do
   describe :class_methods do
     describe :all do
       subject { Unitwise::Search.all }
-      it { subject.must_be_kind_of Enumerable }
-      it { subject.first.must_be_instance_of Unitwise::Unit }
+      it { _(subject).must_be_kind_of Enumerable }
+      it { _(subject.first).must_be_instance_of Unitwise::Unit }
     end
     describe :search do
       it "should return a list of units" do
         search = Unitwise::Search.search('foo')
-        search.must_be_kind_of Enumerable
-        search.first.must_be_instance_of Unitwise::Unit
+        _(search).must_be_kind_of Enumerable
+        _(search.first).must_be_instance_of Unitwise::Unit
       end
     end
   end

--- a/test/unitwise/term_test.rb
+++ b/test/unitwise/term_test.rb
@@ -5,50 +5,50 @@ describe Unitwise::Term do
     subject { Unitwise::Term.new(:atom => 'J', :prefix => 'k')}
     describe "#atom" do
       it "should be an atom" do
-        subject.atom.must_be_instance_of Unitwise::Atom
+        _(subject.atom).must_be_instance_of Unitwise::Atom
       end
     end
 
     describe "#prefix" do
       it "should be a prefix" do
-        subject.prefix.must_be_instance_of Unitwise::Prefix
+        _(subject.prefix).must_be_instance_of Unitwise::Prefix
       end
     end
 
     describe "#exponent" do
       it "should be an integer" do
-        subject.exponent.must_equal 1
+        _(subject.exponent).must_equal 1
       end
     end
 
     describe "#root_terms" do
       it "should be an array of terms" do
-        subject.root_terms.must_be_kind_of Array
-        subject.root_terms.first.must_be_instance_of Unitwise::Term
+        _(subject.root_terms).must_be_kind_of Array
+        _(subject.root_terms.first).must_be_instance_of Unitwise::Term
       end
     end
 
     describe "#composition" do
       it "should be a Multiset" do
-        subject.composition.must_be_instance_of SignedMultiset
+        _(subject.composition).must_be_instance_of SignedMultiset
       end
     end
 
     describe "#scale" do
       it "should return value relative to terminal atoms" do
-        subject.scalar.must_equal 1000000.0
+        _(subject.scalar).must_equal 1000000.0
       end
     end
 
     describe "#frozen?" do
       it "should be frozen" do
-        subject.frozen?.must_equal true
+        _(subject.frozen?).must_equal true
       end
     end
 
     describe "#to_s" do
       it "should return the UCUM code" do
-        subject.to_s.must_equal "kJ"
+        _(subject.to_s).must_equal "kJ"
       end
     end
   end

--- a/test/unitwise/unit_test.rb
+++ b/test/unitwise/unit_test.rb
@@ -11,76 +11,76 @@ describe Unitwise::Unit do
 
   describe "#terms" do
     it "must be a collection of terms" do
-      ms2.must_respond_to :terms
-      ms2.terms.must_be_kind_of Enumerable
-      ms2.terms.first.must_be_instance_of Unitwise::Term
+      _(ms2).must_respond_to :terms
+      _(ms2.terms).must_be_kind_of Enumerable
+      _(ms2.terms.first).must_be_instance_of Unitwise::Term
     end
   end
 
   describe "#root_terms" do
     it "must be an array of Terms" do
-      ms2.must_respond_to :terms
-      ms2.root_terms.must_be_kind_of Array
-      ms2.root_terms.first.must_be_instance_of Unitwise::Term
+      _(ms2).must_respond_to :terms
+      _(ms2.root_terms).must_be_kind_of Array
+      _(ms2.root_terms.first).must_be_instance_of Unitwise::Term
     end
   end
 
   describe "#scalar" do
     it "must return value relative to terminal atoms" do
-      ms2.must_respond_to :scalar
-      ms2.scalar.must_equal 1
-      psi.scalar.must_almost_equal 6894757.293168361
-      deg.scalar.must_almost_equal 0.0174532925199433
+      _(ms2).must_respond_to :scalar
+      _(ms2.scalar).must_equal 1
+      _(psi.scalar).must_almost_equal 6894757.293168361
+      _(deg.scalar).must_almost_equal 0.0174532925199433
     end
   end
 
   describe "#composition" do
     it "must be a multiset" do
-      ms2.must_respond_to :terms
-      ms2.composition.must_be_instance_of SignedMultiset
+      _(ms2).must_respond_to :terms
+      _(ms2.composition).must_be_instance_of SignedMultiset
     end
   end
 
   describe "#dim" do
     it "must be a string representing it's dimensional makeup" do
-      ms2.dim.must_equal 'L.T-2'
-      psi.dim.must_equal 'L-1.M.T-2'
+      _(ms2.dim).must_equal 'L.T-2'
+      _(psi.dim).must_equal 'L-1.M.T-2'
     end
   end
 
   describe "#*" do
     it "should multiply units" do
       mult = kg * ms2
-      mult.expression.to_s.must_match(/kg.*\/s2/)
-      mult.expression.to_s.must_match(/m.*\/s2/)
+      _(mult.expression.to_s).must_match(/kg.*\/s2/)
+      _(mult.expression.to_s).must_match(/m.*\/s2/)
     end
   end
 
   describe "#/" do
     it "should divide units" do
       div = kg / ms2
-      div.expression.to_s.must_match(/kg.*\/m/)
-      div.expression.to_s.must_match(/s2.*\/m/)
+      _(div.expression.to_s).must_match(/kg.*\/m/)
+      _(div.expression.to_s).must_match(/s2.*\/m/)
     end
   end
 
   describe "#frozen?" do
     it "should be frozen" do
       kg.scalar
-      kg.frozen?.must_equal true
+      _(kg.frozen?).must_equal true
     end
   end
 
   describe "#to_s" do
     it "should return an expression in the same mode it was initialized with" do
       ['meter','m', 'mm', '%'].each do |name|
-        Unitwise::Unit.new(name).to_s.must_equal(name)
+        _(Unitwise::Unit.new(name).to_s).must_equal(name)
       end
     end
     it "should accept an optional mode to build the expression with" do
       temp_change = Unitwise::Unit.new("degree Celsius/hour")
-      temp_change.to_s(:primary_code).must_equal("Cel/h")
-      temp_change.to_s(:symbol).must_equal("°C/h")
+      _(temp_change.to_s(:primary_code)).must_equal("Cel/h")
+      _(temp_change.to_s(:symbol)).must_equal("°C/h")
     end
   end
 

--- a/test/unitwise_test.rb
+++ b/test/unitwise_test.rb
@@ -3,28 +3,28 @@ require 'test_helper'
 describe Unitwise do
   describe '()' do
     it "should accept a number and string" do
-      Unitwise(2, 'm/s').must_be_instance_of Unitwise::Measurement
+      _(Unitwise(2, 'm/s')).must_be_instance_of Unitwise::Measurement
     end
     it "should accept a measurement and a string" do
       mass = Unitwise(1, "lb")
       new_mass = Unitwise(mass, "kg")
-      new_mass.value.must_equal(0.45359237)
-      new_mass.unit.to_s.must_equal("kg")
+      _(new_mass.value).must_equal(0.45359237)
+      _(new_mass.unit.to_s).must_equal("kg")
     end
   end
 
   describe 'search' do
     it "must return results" do
-      Unitwise.search('foo').must_be_instance_of(Array)
+      _(Unitwise.search('foo')).must_be_instance_of(Array)
     end
   end
 
   describe 'valid?' do
     it 'should reutrn true for valid unit strings' do
-      Unitwise.valid?('millimeter').must_equal true
+      _(Unitwise.valid?('millimeter')).must_equal true
     end
     it 'should return false for invalid unit strings' do
-      Unitwise.valid?('foo').must_equal false
+      _(Unitwise.valid?('foo')).must_equal false
     end
   end
 
@@ -45,11 +45,11 @@ describe Unitwise do
 
       joshes = Unitwise(1, 'mile').to_jwl
 
-      joshes.to_i.must_equal(881)
+      _(joshes.to_i).must_equal(881)
     end
   end
 
   it "should have a path" do
-    Unitwise.path.must_match(/unitwise$/)
+    _(Unitwise.path).must_match(/unitwise$/)
   end
 end


### PR DESCRIPTION
This PR is a maintenance change to fix the minitest deprecation warnings about using 'global' expectations. 

eg 
```
.DEPRECATED: global use of must_be_kind_of from /Users/stephen/work/ruby/gems/unitwise/test/support/scale_tests.rb:48. Use _(obj).must_be_kind_of instead. This will fail in Minitest 6.
DEPRECATED: global use of must_be_kind_of from /Users/stephen/work/ruby/gems/unitwise/test/support/scale_tests.rb:49. Use _(obj).must_be_kind_of instead. This will fail in Minitest 6.
```

The newer approach is to avoid monkey patching. Objects under test are instead wrapped by calling `_()` 